### PR TITLE
[#151] CnFromPath now correctly handles the case when path is absent

### DIFF
--- a/atom-basis/src/main/java/oo/atom/codegen/cn/AssertClassNamesContainCertainNames.java
+++ b/atom-basis/src/main/java/oo/atom/codegen/cn/AssertClassNamesContainCertainNames.java
@@ -1,0 +1,27 @@
+package oo.atom.codegen.cn;
+
+import io.vavr.collection.HashSet;
+import io.vavr.collection.List;
+import io.vavr.collection.Set;
+import oo.atom.tests.Assertion;
+import org.assertj.core.api.Assertions;
+
+public class AssertClassNamesContainCertainNames implements Assertion {
+    private final ClassNames classNames;
+    private final Set<String> namesToCheck;
+
+    public AssertClassNamesContainCertainNames(ClassNames classNames, Set<String> namesToCheck) {
+        this.classNames = classNames;
+        this.namesToCheck = namesToCheck;
+    }
+
+    public AssertClassNamesContainCertainNames(ClassNames classNames, String namesToCheck) {
+        this(classNames, HashSet.of(namesToCheck));
+    }
+
+    @Override
+    public final void check() throws Exception {
+        List<String> extractedNames = classNames.classNames();
+        Assertions.assertThat(namesToCheck).containsAll(extractedNames);
+    }
+}

--- a/atom-basis/src/main/java/oo/atom/codegen/cn/AssertZeroClassNames.java
+++ b/atom-basis/src/main/java/oo/atom/codegen/cn/AssertZeroClassNames.java
@@ -1,0 +1,17 @@
+package oo.atom.codegen.cn;
+
+import oo.atom.tests.Assertion;
+import org.assertj.core.api.Assertions;
+
+public class AssertZeroClassNames implements Assertion {
+    private final ClassNames classNames;
+
+    public AssertZeroClassNames(ClassNames classNames) {
+        this.classNames = classNames;
+    }
+
+    @Override
+    public final void check() throws Exception {
+        Assertions.assertThat(classNames.classNames()).isEmpty();
+    }
+}

--- a/atom-basis/src/main/java/oo/atom/codegen/cn/CnFromPath.java
+++ b/atom-basis/src/main/java/oo/atom/codegen/cn/CnFromPath.java
@@ -39,6 +39,9 @@ public class CnFromPath implements ClassNames {
     @Override
     public final List<String> classNames() {
         try {
+            if(Files.notExists(path)) {
+                return List.empty();
+            }
             final List<String> classes = Files.find(path, Integer.MAX_VALUE, (p, bf) -> p.toString().endsWith(".class"))
                 .map(path::relativize)
                 .map(Object::toString)

--- a/atom-basis/src/test/java/oo/atom/codegen/cn/CnFromPathTest.java
+++ b/atom-basis/src/test/java/oo/atom/codegen/cn/CnFromPathTest.java
@@ -1,0 +1,19 @@
+package oo.atom.codegen.cn;
+
+import oo.atom.tests.TestCase;
+import oo.atom.tests.TestsSuite;
+
+import java.nio.file.Paths;
+
+class CnFromPathTest extends TestsSuite {
+    public CnFromPathTest() {
+        super(
+            new TestCase(
+                "doesn't fail if the directory is absent",
+                new AssertZeroClassNames(
+                    new CnFromPath(Paths.get("/some-unexisting-path"))
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #151 