### PR TITLE
[#157] A fix for maven plugin

### DIFF
--- a/atom-maven-plugin/src/main/java/oo/atom/maven/GenerateAnnotationsMojo.java
+++ b/atom-maven-plugin/src/main/java/oo/atom/maven/GenerateAnnotationsMojo.java
@@ -9,13 +9,16 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 import java.nio.file.Paths;
 
 @Mojo(name = "generate-annotations", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class GenerateAnnotationsMojo extends AbstractMojo {
-    @Parameter(defaultValue = "${project.basedir}/target/generated-sources/annotations", required = true, readonly = true)
+    @Parameter(defaultValue = "${project.basedir}/target/generated-sources/atom", required = true, readonly = true)
     private String workingDirectory;
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
 
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
@@ -24,5 +27,6 @@ public class GenerateAnnotationsMojo extends AbstractMojo {
             new JpAtomAnnotation(),
             new JpNotAtomAnnotation()
         ).apply();
+        project.addCompileSourceRoot(workingDirectory);
     }
 }


### PR DESCRIPTION
separate generate-sources directory is used for atom annotations